### PR TITLE
Allow to define a bnode label.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,9 +36,13 @@ rdf.NamedNode.prototype.valueOf = function () {
   return this.nominalValue
 }
 
-rdf.BlankNode = function () {
-  this.interfaceName = 'BlankNode'
-  this.nominalValue = 'b' + (++rdf.BlankNode.nextId)
+rdf.BlankNode = function (label) {
+  this.interfaceName = 'BlankNode';
+  if (label != null) {
+    this.nominalValue = label;
+  } else {
+    this.nominalValue = 'b' + (++rdf.BlankNode.nextId);
+  }
 }
 
 rdf.BlankNode.prototype.equals = function (other) {

--- a/index.js
+++ b/index.js
@@ -37,11 +37,11 @@ rdf.NamedNode.prototype.valueOf = function () {
 }
 
 rdf.BlankNode = function (label) {
-  this.interfaceName = 'BlankNode';
+  this.interfaceName = 'BlankNode'
   if (label != null) {
-    this.nominalValue = label;
+    this.nominalValue = label
   } else {
-    this.nominalValue = 'b' + (++rdf.BlankNode.nextId);
+    this.nominalValue = 'b' + (++rdf.BlankNode.nextId)
   }
 }
 


### PR DESCRIPTION
Adds an argument to the BlankNode() constructor function which allows to define a custom bnode label. If omitted, then a unique label is generated (as before).
